### PR TITLE
Prevent prompt to login again, if already logged in. Provide default …

### DIFF
--- a/AzureDataFactory/arm-template-azure-function-app/deploy.ps1
+++ b/AzureDataFactory/arm-template-azure-function-app/deploy.ps1
@@ -67,8 +67,11 @@ Function RegisterRP {
 $ErrorActionPreference = "Stop"
 
 # sign in
-Write-Host "Logging in...";
-Login-AzureRmAccount;
+$context = Get-AzureRmContext;
+if(!$context.Account) {
+    Write-Host "Logging in...";
+    Login-AzureRmAccount;
+}
 
 # select subscription
 Write-Host "Selecting subscription '$subscriptionId'";
@@ -85,8 +88,7 @@ if($resourceProviders.length) {
 
 #Create or check for existing resource group
 $resourceGroup = Get-AzureRmResourceGroup -Name $resourceGroupName -ErrorAction SilentlyContinue
-if(!$resourceGroup)
-{
+if(!$resourceGroup) {
     Write-Host "Resource group '$resourceGroupName' does not exist. To create a new resource group, please enter a location.";
     if(!$resourceGroupLocation) {
         $resourceGroupLocation = Read-Host "resourceGroupLocation";
@@ -100,7 +102,7 @@ else{
 
 # Start the deployment
 Write-Host "Starting deployment...";
-if(Test-Path $parametersFilePath) {
+if($parametersFilePath -and (Test-Path $parametersFilePath)) {
     New-AzureRmResourceGroupDeployment -ResourceGroupName $resourceGroupName -TemplateFile $templateFilePath -TemplateParameterFile $parametersFilePath;
 } else {
     New-AzureRmResourceGroupDeployment -ResourceGroupName $resourceGroupName -TemplateFile $templateFilePath;

--- a/AzureDataFactory/arm-template-azure-function-app/parameters.json
+++ b/AzureDataFactory/arm-template-azure-function-app/parameters.json
@@ -3,16 +3,28 @@
     "contentVersion": "1.0.0.0",
     "parameters": {
         "sites_cdmparser_name": {
-            "value": "l"
+            "value": "",
+            "metadata": {
+                "description": "Globally unique name that identifies your new function app. Valid characters are a-z, 0-9, and -."
+            }
         },
         "serverfarms_cdmparserPlan_name": {
-            "value": ""
+            "value": "",
+            "metadata": {
+                "description": "The Azure function app runs on an App Service Plan. This is a unique name for the name of your app service plan."
+            }
         },
         "storageAccounts_cdmparserstorage_name": {
-            "value": ""
+            "value": "",
+            "metadata": {
+                "description": "Name of the storage account used by your function app. You can create a new one or use an existing one. Must be lowercase alphanumeric characters, globally unique, and between 3 and 24 characters in length."
+            }
         },
         "hostNameBindings_cdmparser.azurewebsites.net_name": {
-            "value": "<insert parameter value: "sites_cdmparser_name" >.azurewebsites.net"
+            "value": "",
+            "metadata": {
+                "description": "This will be in format of '<your unique name>.azurewebsites.net'"
+            }
         }
     }
 }

--- a/AzureDataFactory/arm-template-azure-function-app/template.json
+++ b/AzureDataFactory/arm-template-azure-function-app/template.json
@@ -3,16 +3,20 @@
     "contentVersion": "1.0.0.0",
     "parameters": {
         "sites_cdmparser_name": {
-            "type": "String"
+            "type": "string",
+            "defaultValue": "[concat('CDM-', uniqueString(subscription().subscriptionId, resourceGroup().id), '-Site')]"
         },
         "serverfarms_cdmparserPlan_name": {
-            "type": "String"
+            "type": "string",
+            "defaultValue": "[concat('CDM-', uniqueString(subscription().subscriptionId, resourceGroup().id), '-Plan')]"
         },
         "storageAccounts_cdmparserstorage_name": {
-            "type": "String"
+            "type": "string",
+            "defaultValue": "[concat('cdm', uniqueString(subscription().subscriptionId, resourceGroup().id), 'stg')]"
         },
         "hostNameBindings_cdmparser.azurewebsites.net_name": {
-            "type": "String"
+            "type": "string",
+            "defaultValue": "[concat(parameters('sites_cdmparser_name'), '.azurewebsites.net')]"
         }
     },
     "variables": {},


### PR DESCRIPTION
…parameters that will work for Azure Function deployment.

## Purpose
* Do not prompt to login to Azure if the user is already logged in.
* Update template.json with good defaults (assuming no name conflicts exist) so the template runs fine out of the box, and parameter descriptions to parameters.json.

## Does this introduce a breaking change?
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?
!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [drwill/AzureFuncArmProvision]
```

* Test the code
```
// In PowerShell:
cd AzureDataFactory\arm-template-azure-function-app
.\deploy.ps1 <with parameters including unique rg>
// Confirm prompted to login

// Manually login
Login-AzureRmAccount
.\deploy.ps1 <with parameters including unique rg and -parametersFilePath "">
// Confirm not prompted to login again
```

## What to Check
Verify that the following are valid
* No errors during provision
* Resources appear in specified Azure subscription and resource group

## Other Information
The login check is standard code I've used before.

I thought it would be helpful, in case someone didn't edit/include the parameters.json file, that the deployment might work out of the box.